### PR TITLE
Issue 7: Make `EpiAwarePipeline` easy to install

### DIFF
--- a/EpiAware/src/EpiInfModels/ODEProcess.jl
+++ b/EpiAware/src/EpiInfModels/ODEProcess.jl
@@ -292,7 +292,9 @@ nothing
 
 """
 @model function EpiAwareBase.generate_latent_infs(epi_model::ODEProcess, Z_t)
-    prob, solver, sol2infs, solver_options = epi_model.params.prob,
+    prob, solver,
+    sol2infs,
+    solver_options = epi_model.params.prob,
     epi_model.solver, epi_model.sol2infs, epi_model.solver_options
     n = isnothing(Z_t) ? 0 : size(Z_t, 1)
 

--- a/EpiAware/src/EpiObsModels/utils.jl
+++ b/EpiAware/src/EpiObsModels/utils.jl
@@ -13,6 +13,7 @@ function generate_observation_kernel(delay_int, time_horizon; partial::Bool = tr
     if (partial)
         K = zeros(eltype(delay_int), time_horizon, time_horizon) |> SparseMatrixCSC
         for i in 1:time_horizon, j in 1:time_horizon
+
             m = i - j
             if m >= 0 && m <= (length(delay_int) - 1)
                 K[i, j] = delay_int[m + 1]

--- a/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
@@ -263,6 +263,7 @@ end
     #Test the parameter recovery for all combinations of latent processes and epi models
     @testset "Check true parameters are within 99% central post. prob.: " begin
         @testset for latentprocess_type in latentprocess_types, epimodel in epimodels
+
             latentprocess = set_latent_process(epimodel, latentprocess_type)
             @suppress _ = test_full_process(epimodel, latentprocess, 40)
         end

--- a/EpiAware/test/EpiObsModels/modifiers/ascertainment/helpers.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/ascertainment/helpers.jl
@@ -6,7 +6,7 @@
     end
 
     @model EpiAware.EpiAwareBase.generate_observations(model::ExpectedObs, y_t,
-    Y_t) = begin
+        Y_t) = begin
         expected_obs := Y_t
         @submodel y_t = generate_observations(model.model, y_t, Y_t)
     end

--- a/pipeline/Project.toml
+++ b/pipeline/Project.toml
@@ -33,5 +33,7 @@ RCall = "6f49c342-dc21-5d91-9882-a32aef131414"
 RCallExt = "RCall"
 
 [compat]
-EpiAware = "0.1.0"
 julia = ">= 1.10"
+
+[sources]
+EpiAware = {url="https://github.com/seabbs/Rt-without-renewal", subdir="EpiAware", rev="main"}

--- a/pipeline/src/analysis/config_mappings.jl
+++ b/pipeline/src/analysis/config_mappings.jl
@@ -17,9 +17,10 @@ function _get_info_from_config(inference_config)
     latent_model = inference_config["latent_model"]
     used_gi_mean = inference_config["gi_mean"]
     used_gi_std = inference_config["gi_std"]
-    (start_time, reference_time) = inference_config["tspan"] |>
-                                   tspan -> split(tspan, "_") |>
-                                            tspan -> (
+    (start_time,
+        reference_time) = inference_config["tspan"] |>
+                          tspan -> split(tspan, "_") |>
+                                   tspan -> (
         parse(Int, tspan[1]), parse(Int, tspan[2]))
 
     #Get the quantiles for the targets across the gi mean scenarios

--- a/pipeline/src/constructors/remake_latent_model.jl
+++ b/pipeline/src/constructors/remake_latent_model.jl
@@ -19,9 +19,10 @@ function remake_latent_model(
     prior_dict = make_model_priors(pipeline)
     igp = inference_config["igp"]
     default_latent_model = inference_config["latent_namemodels"].second
-    target_std, target_autocorr = default_latent_model isa AR ?
-                                  _make_target_std_and_autocorr(igp; stationary = true) :
-                                  _make_target_std_and_autocorr(igp; stationary = false)
+    target_std,
+    target_autocorr = default_latent_model isa AR ?
+                      _make_target_std_and_autocorr(igp; stationary = true) :
+                      _make_target_std_and_autocorr(igp; stationary = false)
 
     return _implement_latent_process(
         target_std, target_autocorr, default_latent_model, pipeline)

--- a/pipeline/src/plotting/figureone.jl
+++ b/pipeline/src/plotting/figureone.jl
@@ -6,12 +6,12 @@ Filter the `predictions` DataFrame for `scenario`, `target`, `reference_time`,
 function _fig1_pred_filter(predictions, scenario, target, reference_time,
         latent_model; true_gi_choice = 2.0, used_gi_choice = 2.0)
     df = predictions |>
-         df -> @subset(df, :Latent_Model.==latent_model) |>
-               df -> @subset(df, :True_GI_Mean.==true_gi_choice) |>
-                     df -> @subset(df, :Used_GI_Mean.==used_gi_choice) |>
-                           df -> @subset(df, :Reference_Time.==reference_time) |>
-                                 df -> @subset(df, :Scenario.==scenario) |>
-                                       df -> @subset(df, :Target.==target)
+         df -> @subset(df, :Latent_Model .== latent_model) |>
+               df -> @subset(df, :True_GI_Mean .== true_gi_choice) |>
+                     df -> @subset(df, :Used_GI_Mean .== used_gi_choice) |>
+                           df -> @subset(df, :Reference_Time .== reference_time) |>
+                                 df -> @subset(df, :Scenario .== scenario) |>
+                                       df -> @subset(df, :Target .== target)
     return df
 end
 

--- a/pipeline/src/plotting/figuretwo.jl
+++ b/pipeline/src/plotting/figuretwo.jl
@@ -1,13 +1,13 @@
 function _fig2_pred_filter(predictions, scenario, target, latent_model, horizon;
         true_gi_choice, used_gi_choice, horizon_diff = 7)
     df = predictions |>
-         df -> @subset(df, :Latent_Model.==latent_model) |>
-               df -> @subset(df, :True_GI_Mean.==true_gi_choice) |>
-                     df -> @subset(df, :Used_GI_Mean.==used_gi_choice) |>
+         df -> @subset(df, :Latent_Model .== latent_model) |>
+               df -> @subset(df, :True_GI_Mean .== true_gi_choice) |>
+                     df -> @subset(df, :Used_GI_Mean .== used_gi_choice) |>
                            df -> @subset(df,
-        horizon-horizon_diff.<(:target_times.-:Reference_Time).<=horizon) |>
-                                 df -> @subset(df, :Scenario.==scenario) |>
-                                       df -> @subset(df, :Target.==target)
+        horizon-horizon_diff .< (:target_times .- :Reference_Time) .<= horizon) |>
+                                 df -> @subset(df, :Scenario .== scenario) |>
+                                       df -> @subset(df, :Target .== target)
     return df
 end
 

--- a/pipeline/src/plotting/panel_plots.jl
+++ b/pipeline/src/plotting/panel_plots.jl
@@ -66,8 +66,8 @@ Filter the `truth` DataFrame for `scenario`, `target`, `latent_model`, `true_gi_
 """
 function _fig_truth_filter(truth, scenario, target; true_gi_choice)
     df = truth |>
-         df -> @subset(df, :True_GI_Mean.==true_gi_choice) |>
-               df -> @subset(df, :Scenario.==scenario) |>
-                     df -> @subset(df, :Target.==target)
+         df -> @subset(df, :True_GI_Mean .== true_gi_choice) |>
+               df -> @subset(df, :Scenario .== scenario) |>
+                     df -> @subset(df, :Target .== target)
     return df
 end


### PR DESCRIPTION
This PR closes #7 .

This PR adds a `url`, `subdir` and `rev` (main) to the `EpiAwarePipeline` project file. This means the pkg loads without extra effort.

Also, this PR reformats some files. It seems that the `sciml` style for `JuliaFormatter` has changed a bit. I don't know how to pin some historic version so I suggest just going with it.