### PR TITLE
Issue 11: Add `scoringutils` R package installer and fix `score_parameters`

### DIFF
--- a/pipeline/ext/RCallExt.jl
+++ b/pipeline/ext/RCallExt.jl
@@ -3,5 +3,6 @@ module RCallExt
 using EpiAwarePipeline, RCall, DataFramesMeta
 
 include("install_scoringutils.jl")
+include("score.jl")
 include("score_parameters.jl")
 end

--- a/pipeline/ext/RCallExt.jl
+++ b/pipeline/ext/RCallExt.jl
@@ -2,5 +2,6 @@ module RCallExt
 
 using EpiAwarePipeline, RCall, DataFramesMeta
 
+include("install_scoringutils.jl")
 include("score_parameters.jl")
 end

--- a/pipeline/ext/install_scoringutils.jl
+++ b/pipeline/ext/install_scoringutils.jl
@@ -1,0 +1,25 @@
+"""
+    EpiAwarePipeline.install_scoringutils(; force = false, quiet = true)
+
+Installs the `scoringutils` R package from the `epiforecasts/scoringutils` GitHub repository
+using the `pacman` R package manager. If `pacman` is not already installed, it will be installed first.
+
+# Arguments
+- `force::Bool`: If `true`, forces reinstallation of `scoringutils` even if it is already installed. Defaults to `false`.
+- `quiet::Bool`: If `true`, suppresses output during installation. Defaults to `true`.
+
+# Returns
+- `nothing`: This function does not return any value.
+"""
+function EpiAwarePipeline.install_scoringutils(; force = false, quiet = true)
+    R"""
+    if (!requireNamespace("pacman", quietly = TRUE)) {
+        install.packages("pacman", dependencies = TRUE, quiet = TRUE, ask = FALSE)
+    }
+    pacman::p_install_gh("epiforecasts/scoringutils",
+                          dependencies = TRUE,
+                          force = $force,
+                          quiet = $quiet)
+    """
+    return nothing
+end

--- a/pipeline/ext/install_scoringutils.jl
+++ b/pipeline/ext/install_scoringutils.jl
@@ -1,25 +1,29 @@
 """
     EpiAwarePipeline.install_scoringutils(; force = false, quiet = true)
 
-Installs the `scoringutils` R package from the `epiforecasts/scoringutils` GitHub repository
-using the `pacman` R package manager. If `pacman` is not already installed, it will be installed first.
+Installs the R package `scoringutils` version 2.1 using the `pacman` package manager.
+If `pacman` is not installed, it will be installed first.
 
 # Arguments
-- `force::Bool`: If `true`, forces reinstallation of `scoringutils` even if it is already installed. Defaults to `false`.
+- `force::Bool`: If `true`, forces the reinstallation of the package even if it is already installed. Defaults to `false`.
 - `quiet::Bool`: If `true`, suppresses output during installation. Defaults to `true`.
 
 # Returns
 - `nothing`: This function does not return any value.
+
+# Notes
+- This function uses embedded R code to perform the installation.
+- Ensure that R is properly configured and accessible from your Julia environment.
 """
 function EpiAwarePipeline.install_scoringutils(; force = false, quiet = true)
     R"""
     if (!requireNamespace("pacman", quietly = TRUE)) {
         install.packages("pacman", dependencies = TRUE, quiet = TRUE, ask = FALSE)
     }
-    pacman::p_install_gh("epiforecasts/scoringutils",
-                          dependencies = TRUE,
-                          force = $force,
-                          quiet = $quiet)
+    pacman::p_install("scoringutils",
+                        dependencies = TRUE,
+                        force = $force,
+                        quiet = $quiet)
     """
     return nothing
 end

--- a/pipeline/ext/score.jl
+++ b/pipeline/ext/score.jl
@@ -1,0 +1,53 @@
+"""
+    score(df::DataFrame; transform_forecasts = true)
+
+Scores the forecast samples in the given DataFrame using the `scoringutils` R package.
+
+# Arguments
+- `df::DataFrame`: A DataFrame containing forecast samples to be scored.
+- `transform_forecasts::Bool`: A keyword argument indicating whether to apply the `transform_forecasts()` function to the scored results. Defaults to `true`.
+
+# Returns
+- The scored results as a `DataFrame`.
+
+# Details
+- If `transform_forecasts` is `true`, the `scoringutils::transform_forecasts()` R function is applied to the scored results.
+- The function uses RCall to execute R code and interact with the `scoringutils` package.
+
+# Dataframe Structure
+The input DataFrame `df` should contain the following columns:
+- `predicted`: The predicted values from the forecast samples.
+- `observed`: The observed values (truth) corresponding to the predictions.
+- `model`: The name of the model used for the predictions.
+- `parameter`: The name of the parameter being scored.
+- `sample_id`: An identifier for each sample in the DataFrame.
+
+To create such a DataFrame, you can use the `make_prediction_dataframe` utility function from the `EpiAwarePipeline` package.
+
+# Dependencies
+Requires the `RCall` Julia package and the `scoringutils` R package to be installed and available.
+To install the `scoringutils` package as part of `EpiAwarePipeline` usage you can run:
+
+```julia
+using EpiAwarePipeline, RCall
+install_scoringutils()
+```
+
+"""
+function EpiAwarePipeline.score(df::DataFrame; transform_forecasts = true)
+    rresult = transform_forecasts ?
+              R"""
+               library(scoringutils)
+               result <- $df |>
+                   as_forecast_sample() |>
+                   transform_forecasts(append = FALSE) |>
+                   score()
+               """ :
+              R"""
+              library(scoringutils)
+               result <- $df |>
+                   as_forecast_sample() |>
+                   score()
+              """
+    return rcopy(rresult)
+end

--- a/pipeline/ext/score.jl
+++ b/pipeline/ext/score.jl
@@ -39,14 +39,18 @@ function EpiAwarePipeline.score(df::DataFrame; transform_forecasts = true)
               R"""
                library(scoringutils)
                result <- $df |>
-                   as_forecast_sample() |>
+                   as_forecast_sample(
+                    forecast_unit = c("model", "parameter")
+                   ) |>
                    transform_forecasts(append = FALSE) |>
                    score()
                """ :
               R"""
               library(scoringutils)
                result <- $df |>
-                   as_forecast_sample() |>
+                   as_forecast_sample(
+                    forecast_unit = c("model", "parameter")
+                   ) |>
                    score()
               """
     return rcopy(rresult)

--- a/pipeline/ext/score_parameters.jl
+++ b/pipeline/ext/score_parameters.jl
@@ -1,45 +1,8 @@
-"""
-Internal function for making a DataFrame for a given parameter using the
-    provided MCMC samples and the truth value.
-"""
-function _make_prediction_dataframe(param_name, samples, truth; model = "EpiAware")
-    x = samples[Symbol(param_name)][:]
-    DataFrame(predicted = x, observed = truth, model = model,
-        parameter = param_name, sample_id = 1:length(x))
-end
-
-"""
-Internal function for scoring a DataFrame containing a prediction and truth value
-    for a parameter using the `scoringutils` package.
-"""
-function _score(df)
-    @rput df
-    R"""
-    library(scoringutils)
-    result = df |> as_forecast() |> score()
-    """
-    @rget result
-    return result
-end
-
-"""
-This method for `score_parameters` calculates standard scores provided by [`scoringutils`](https://epiforecasts.io/scoringutils/dev/)
-for a set of parameters using the provided MCMC samples and the truth value.
-The function returns a DataFrame containing a summary of the scores.
-
-## Arguments
-- `param_names`: Names of the parameter to score.
-- `samples`: A `MCMCChains.Chains` object of samples.
-- `truths`: Truth values for each parameter.
-- `model`: (optional) The name of the model. Default is "EpiAware".
-
-## Returns
-- `result`: A DataFrame containing the summarized scores for the parameter.
-
-"""
-function EpiAwarePipeline.score_parameters(param_names, samples, truths; model = "EpiAware")
+function EpiAwarePipeline.score_parameters(
+        param_names, samples, truths; model = "EpiAware", transform_forecasts = true)
     df = mapreduce(vcat, param_names, truths) do param_name, truth
-        _make_prediction_dataframe(param_name, samples, truth; model = model)
+        score(make_prediction_dataframe(param_name, samples, truth; model),
+            transform_forecasts = transform_forecasts)
     end
-    return _score(df)
+    return df
 end

--- a/pipeline/ext/score_parameters.jl
+++ b/pipeline/ext/score_parameters.jl
@@ -1,3 +1,21 @@
+"""
+    EpiAwarePipeline.score_parameters(param_names, samples, truths; model="EpiAware", transform_forecasts=true)
+
+Scores the parameters of a model by comparing predictions against ground truth values.
+
+# Arguments
+- `param_names::Vector{String}`: A list of parameter names to be scored.
+- `samples::Any`: The sampled predictions for the parameters.
+- `truths::Any`: The ground truth values corresponding to the parameters.
+- `model::String="EpiAware"`: The name of the model used for scoring. Defaults to `"EpiAware"`.
+- `transform_forecasts::Bool=true`: Whether to transform forecasts before scoring. Defaults to `true`.
+
+# Returns
+- `df::DataFrame`: A DataFrame containing the scores for each parameter.
+
+# Notes
+This function uses `make_prediction_dataframe` to generate prediction dataframes for each parameter and `score` to compute the scores. The results are aggregated into a single DataFrame.
+"""
 function EpiAwarePipeline.score_parameters(
         param_names, samples, truths; model = "EpiAware", transform_forecasts = true)
     df = mapreduce(vcat, param_names, truths) do param_name, truth

--- a/pipeline/src/EpiAwarePipeline.jl
+++ b/pipeline/src/EpiAwarePipeline.jl
@@ -43,7 +43,7 @@ export infer, generate_inference_results, map_inference_results, define_epiprob
 export define_forecast_epiprob, generate_forecasts
 
 # Exported functions: scoring functions
-export score_parameters, simple_crps, summarise_crps, install_scoringutils
+export score_parameters, simple_crps, summarise_crps, install_scoringutils, score
 
 # Exported functions: Analysis functions for constructing dataframes
 export make_prediction_dataframe_from_output, make_truthdata_dataframe,

--- a/pipeline/src/EpiAwarePipeline.jl
+++ b/pipeline/src/EpiAwarePipeline.jl
@@ -43,7 +43,7 @@ export infer, generate_inference_results, map_inference_results, define_epiprob
 export define_forecast_epiprob, generate_forecasts
 
 # Exported functions: scoring functions
-export score_parameters, simple_crps, summarise_crps
+export score_parameters, simple_crps, summarise_crps, install_scoringutils
 
 # Exported functions: Analysis functions for constructing dataframes
 export make_prediction_dataframe_from_output, make_truthdata_dataframe,

--- a/pipeline/src/EpiAwarePipeline.jl
+++ b/pipeline/src/EpiAwarePipeline.jl
@@ -18,7 +18,7 @@ export AbstractEpiAwarePipeline, EpiAwarePipeline, AbstractRtwithoutRenewalPipel
 
 # Exported utility functions
 export calculate_processes, generate_quantiles_for_targets,
-       timeseries_samples_into_quantiles
+       timeseries_samples_into_quantiles, make_prediction_dataframe
 
 # Exported configuration types
 export TruthSimulationConfig, InferenceConfig

--- a/pipeline/src/scoring/scoring.jl
+++ b/pipeline/src/scoring/scoring.jl
@@ -12,3 +12,10 @@ Base function for installing the `scoringutils` package in R, intended to be
     extended conditional on other dependency packages, e.g. `RCall`.
 """
 function install_scoringutils end
+
+"""
+Base function for scoring a DataFrame containing a prediction and truth value.
+Intended to be extended conditional on other dependency packages, such as the
+    R package `scoringutils` via `RCall`.
+"""
+function score end

--- a/pipeline/src/scoring/scoring.jl
+++ b/pipeline/src/scoring/scoring.jl
@@ -6,3 +6,9 @@ Base function for scoring parameters intended to be extended conditional on othe
     dependency packages, such as the R package `scoringutils` via `RCall`.
 """
 function score_parameters end
+
+"""
+Base function for installing the `scoringutils` package in R, intended to be
+    extended conditional on other dependency packages, e.g. `RCall`.
+"""
+function install_scoringutils end

--- a/pipeline/src/utils/make_prediction_dataframe.jl
+++ b/pipeline/src/utils/make_prediction_dataframe.jl
@@ -1,0 +1,32 @@
+"""
+Create a DataFrame containing predicted values, observed values, model name, parameter name,
+and sample IDs based on the provided samples and truth data.
+
+# Arguments
+- `param_name::String`: The name of the parameter to extract from the samples.
+- `samples::Dict{Symbol, Vector}`: A dictionary containing sampled data, where keys are parameter names as symbols.
+- `truth::Vector`: A vector of observed values corresponding to the parameter.
+- `model::String` (optional): The name of the model. Defaults to `"EpiAware"`.
+
+# Returns
+- `DataFrame`: A DataFrame with the following columns:
+  - `predicted`: The sampled values for the specified parameter.
+  - `observed`: The truth values provided.
+  - `model`: The model name.
+  - `parameter`: The name of the parameter.
+  - `sample_id`: The index of each sample.
+
+NB: The `samples` object must allow `getindex` to access the parameter values with `param_name`
+coerceable to a `Symbol` and the `truth` value should be a single value or a vector of same length
+ as the number of samples. An example would be a `MCMCChains.Chains` object as samples and a single
+    truth value for the parameter.
+"""
+function make_prediction_dataframe(param_name, samples, truth; model = "EpiAware")
+    x = samples[Symbol(param_name)][:]
+    DataFrame(predicted = x, observed = truth, model = model,
+        parameter = param_name, sample_id = 1:length(x))
+end
+
+# """
+
+# """

--- a/pipeline/src/utils/utils.jl
+++ b/pipeline/src/utils/utils.jl
@@ -1,3 +1,4 @@
 include("calculate_processes.jl")
 include("scenario_names_utils.jl")
 include("timeseries_utils.jl")
+include("make_prediction_dataframe.jl")

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -7,6 +7,6 @@ include("constructors/test_constructors.jl");
 include("simulate/test_simulate.jl");
 include("infer/test_infer.jl");
 include("forecast/test_forecast.jl");
-include("scoring/test_score_parameters.jl");
+include("scoring/test_scoring.jl");
 include("plotting/plotting_tests.jl");
 include("pipeline/test_pipeline.jl");

--- a/pipeline/test/scoring/test_install_scoringutils.jl
+++ b/pipeline/test/scoring/test_install_scoringutils.jl
@@ -1,0 +1,41 @@
+@testset "EpiAwarePipeline.install_scoringutils Tests" begin
+    # Test 1: Check if the function runs without errors with default arguments
+    @testset "Default Arguments" begin
+        try
+            EpiAwarePipeline.install_scoringutils()
+            @test true  # If no error occurs, the test passes
+        catch e
+            @test false
+        end
+    end
+
+    # Test 2: Check if the function runs without errors with force = true
+    @testset "Force Installation" begin
+        try
+            EpiAwarePipeline.install_scoringutils(force = true)
+            @test true  # If no error occurs, the test passes
+        catch e
+            @test false
+        end
+    end
+
+    # Test 3: Check if the function runs without errors with quiet = false
+    @testset "Verbose Installation" begin
+        try
+            EpiAwarePipeline.install_scoringutils(quiet = false)
+            @test true  # If no error occurs, the test passes
+        catch e
+            @test false
+        end
+    end
+
+    # Test 4: Check if the function runs without errors with both force = true and quiet = false
+    @testset "Force and Verbose Installation" begin
+        try
+            EpiAwarePipeline.install_scoringutils(force = true, quiet = false)
+            @test true  # If no error occurs, the test passes
+        catch e
+            @test false
+        end
+    end
+end

--- a/pipeline/test/scoring/test_score.jl
+++ b/pipeline/test/scoring/test_score.jl
@@ -1,6 +1,5 @@
 @testset "score function tests" begin
     using DataFramesMeta
-    install_scoringutils()  # Ensure scoringutils is installed
 
     function create_mock_dataframe(; n = 5)
         DataFrame(

--- a/pipeline/test/scoring/test_score.jl
+++ b/pipeline/test/scoring/test_score.jl
@@ -1,0 +1,35 @@
+@testset "score function tests" begin
+    using DataFramesMeta
+    install_scoringutils()  # Ensure scoringutils is installed
+
+    function create_mock_dataframe(; n = 5)
+        DataFrame(
+            predicted = exp.(randn(n)),
+            observed = ones(n),
+            model = fill("model1", n),
+            parameter = fill("param1", n),
+            sample_id = collect(1:n)
+        )
+    end
+
+    # Test 1: Basic functionality without transformation
+    df = create_mock_dataframe()
+    result = score(df; transform_forecasts = false)
+    @test isa(result, DataFrame)
+    @test "model" ∈ names(result)
+    @test "parameter" ∈ names(result)
+
+    # Test 2: Functionality with transformation
+    result_transformed = score(df; transform_forecasts = true)
+    @test isa(result_transformed, DataFrame)
+    @test "model" ∈ names(result)
+    @test "parameter" ∈ names(result)
+
+    # Test 3: Edge case - Empty DataFrame
+    empty_df = DataFrame()
+    @test_throws RCall.REvalError score(empty_df)
+
+    # Test 4: Invalid DataFrame structure
+    invalid_df = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
+    @test_throws RCall.REvalError score(invalid_df)
+end

--- a/pipeline/test/scoring/test_score.jl
+++ b/pipeline/test/scoring/test_score.jl
@@ -21,7 +21,7 @@
     # Test 2: Functionality with transformation
     result_transformed = score(df; transform_forecasts = true)
     @test isa(result_transformed, DataFrame)
-    @test "model" ∈ names(result)
+    @test "model" ∈ names(result_transformed)
     @test "parameter" ∈ names(result)
 
     # Test 3: Edge case - Empty DataFrame

--- a/pipeline/test/scoring/test_score_parameters.jl
+++ b/pipeline/test/scoring/test_score_parameters.jl
@@ -1,11 +1,25 @@
-# @testset "score_parameter tests" begin
-#     using MCMCChains, RCall
+@testset "score_parameter tests" begin
+    using DataFramesMeta, MCMCChains
 
-#     samples = MCMCChains.Chains(0.5 .+ randn(1000, 2, 1), [:a, :b])
-#     truths = fill(0.5, 2)
-#     result = score_parameters(["a", "b"], samples, truths)
+    samples = MCMCChains.Chains(exp.(0.5 .+ randn(1000, 2, 1)), [:a, :b])
+    truths = fill(exp(0.5), 2)
+    result = score_parameters(["a", "b"], samples, truths;
+        model = "EpiAware",
+        transform_forecasts = false)
 
-#     @test result.parameter == ["a", "b"]
-#     #Bias should be close to 0 in this example
-#     @test all(result.bias .< 0.1)
-# end
+    @test isa(result, DataFrame)
+    @test "parameter" in names(result)
+    @test "model" in names(result)
+    @test "crps" in names(result)
+    @test all(result.model .== "EpiAware")
+
+    # Test with transformation and different model name
+    result_transformed = score_parameters(["a", "b"], samples, truths;
+        model = "CustomModel",
+        transform_forecasts = true)
+    @test isa(result_transformed, DataFrame)
+    @test "parameter" in names(result_transformed)
+    @test "model" in names(result_transformed)
+    @test "crps" in names(result_transformed)
+    @test all(result_transformed.model .== "CustomModel")
+end

--- a/pipeline/test/scoring/test_scoring.jl
+++ b/pipeline/test/scoring/test_scoring.jl
@@ -1,3 +1,4 @@
 using RCall # Activate RCall extension
 include("test_install_scoringutils.jl")
 include("test_score_parameters.jl")
+include("test_score.jl")

--- a/pipeline/test/scoring/test_scoring.jl
+++ b/pipeline/test/scoring/test_scoring.jl
@@ -1,0 +1,3 @@
+using RCall # Activate RCall extension
+include("test_install_scoringutils.jl")
+include("test_score_parameters.jl")

--- a/pipeline/test/scoring/test_scoring.jl
+++ b/pipeline/test/scoring/test_scoring.jl
@@ -1,4 +1,5 @@
 using RCall # Activate RCall extension
+install_scoringutils()  # Ensure scoringutils is installed
 include("test_install_scoringutils.jl")
 include("test_score_parameters.jl")
 include("test_score.jl")

--- a/pipeline/test/utils/test_make_prediction_dataframe.jl
+++ b/pipeline/test/utils/test_make_prediction_dataframe.jl
@@ -1,0 +1,24 @@
+@testset "make_prediction_dataframe tests" begin
+    using DataFramesMeta
+    # Mock data for testing
+    samples_mock = Dict(:param1 => [1.0, 2.0, 3.0])
+    truth_mock = [1.5, 2.5, 3.5]
+    # Test 1: Basic functionality
+    df = make_prediction_dataframe("param1", samples_mock, truth_mock)
+    @test isa(df, DataFrame)
+    @test all(df.predicted .== [1.0, 2.0, 3.0])
+    @test all(df.observed .== [1.5, 2.5, 3.5])
+    @test all(df.model .== "EpiAware")
+    @test all(df.parameter .== "param1")
+    @test all(df.sample_id .== [1, 2, 3])
+
+    # Test 2: Single truth value
+    truth_single = 2.0
+    df_single_truth = make_prediction_dataframe("param1", samples_mock, truth_single)
+    @test all(df_single_truth.observed .== 2.0)
+
+    # Test 3: Custom model name
+    df_custom_model = make_prediction_dataframe(
+        "param1", samples_mock, truth_mock; model = "CustomModel")
+    @test all(df_custom_model.model .== "CustomModel")
+end

--- a/pipeline/test/utils/test_utils.jl
+++ b/pipeline/test/utils/test_utils.jl
@@ -1,2 +1,3 @@
 include("test_calculate_processes.jl")
 include("test_simple_crps.jl")
+include("test_make_prediction_dataframe.jl")


### PR DESCRIPTION
This PR closes #11 

This pull request fixes using `scoringutils` versions `>2.0` for the scoring functionality in the `EpiAwarePipeline` package. It replaces older internal methods with more modular and extensible implementations, adds documentation, and expands test coverage for these features (which had become broken).

### Scoring Enhancements

* **New `score` function**: Implements scoring of forecast samples using the `scoringutils` R package, with optional transformation of results via `transform_forecasts`. The function uses RCall to execute R code. (`pipeline/ext/score.jl`, [pipeline/ext/score.jlR1-R57](diffhunk://#diff-235ea75247f9906d714e50ab4411a74727c1463bc92f76bc20fa971b594dc428R1-R57))
* **Updated `score_parameters` function**: Refactored to use the new `score` function and added support for `transform_forecasts` as a keyword argument. (`pipeline/ext/score_parameters.jl`, [pipeline/ext/score_parameters.jlL1-R7](diffhunk://#diff-7c7895945fa89a424c8d8cd9a615746aea1e9ab1807abb93f46a72ac0f4d71d8L1-R7))

### Dependency Management

* **New `install_scoringutils` function**: Automates installation of the `scoringutils` R package via the `pacman` package manager, with options for forced reinstallation and output suppression. (`pipeline/ext/install_scoringutils.jl`, [pipeline/ext/install_scoringutils.jlR1-R25](diffhunk://#diff-268b0d975507ff58d601014c07faef1c3c10b81959de03f83abd0daa80321ad9R1-R25))

### Utility Functions

* **New `make_prediction_dataframe` function**: Creates a standardized DataFrame for scoring, containing predicted values, observed values, model name, parameter name, and sample IDs. (`pipeline/src/utils/make_prediction_dataframe.jl`, [pipeline/src/utils/make_prediction_dataframe.jlR1-R32](diffhunk://#diff-76c1929b10853e963baf2bc59b5dad5a031d973cf7816a58865b70d17ffb2e5dR1-R32))

### Codebase Refactoring

* **Removed internal methods**: Deprecated `_make_prediction_dataframe` and `_score` functions, consolidating their functionality into the new modular methods. (`pipeline/ext/score_parameters.jl`, [pipeline/ext/score_parameters.jlL1-R7](diffhunk://#diff-7c7895945fa89a424c8d8cd9a615746aea1e9ab1807abb93f46a72ac0f4d71d8L1-R7))
* **Export updates**: Added `install_scoringutils`, `score`, and `make_prediction_dataframe` to the list of exported functions in `EpiAwarePipeline`. (`pipeline/src/EpiAwarePipeline.jl`, [[1]](diffhunk://#diff-c2e26149bc0aa84bffaea294efd4fe33c2762cc2693eb350390588095a7f9ba5L21-R21) [[2]](diffhunk://#diff-c2e26149bc0aa84bffaea294efd4fe33c2762cc2693eb350390588095a7f9ba5L46-R46)

### Test Coverage

* **New test files**: Added comprehensive test cases for `install_scoringutils`, `score`, `score_parameters`, and `make_prediction_dataframe`. (`pipeline/test/scoring/test_install_scoringutils.jl`, [[1]](diffhunk://#diff-742d4f8ee898c30c16d46eaf0682e2728619da0f8b769733b54438ba975a0a3aR1-R41); `pipeline/test/scoring/test_score.jl`, [[2]](diffhunk://#diff-e44c6756dceeec7bcd8b30df2e90132840f84a732cd502b22ca7bdb9970f7542R1-R34); `pipeline/test/scoring/test_score_parameters.jl`, [[3]](diffhunk://#diff-d0203067420346cc1d791b1cf3e36e27ef812318a5cd2cb17442c7993be55f27L1-R25); `pipeline/test/utils/test_make_prediction_dataframe.jl`, [[4]](diffhunk://#diff-d6a16ea0d93caf602466958504f66e8d32e7c502664ba84fec533e3788876097R1-R24)
* **Test refactoring**: Updated `runtests.jl` to include new test files and removed outdated test references. (`pipeline/test/runtests.jl`, [pipeline/test/runtests.jlL10-R10](diffhunk://#diff-d5af153e3a46de09d96842e8b0b1655d8ca12e4cf6226094b67aa834e2be22b4L10-R10))

### Segfault

I've found that for reasonable sized test `samples` (e.g. > 1000 samples) objects trying to 

1. For each parameter
  a. make a prediction dataframe
2.`vcat` prediction dataframes 
3. Pass to `scores`

Creates a Segfault (some searching seems to suggest this is hard to debug but fairly common `RCall` error).

To reprex this error change `score_parameters` at `pipeline/ext/score_parameters.jl` to

```julia
function EpiAwarePipeline.score_parameters(
        param_names, samples, truths; model = "EpiAware", transform_forecasts = true)
    df = mapreduce(vcat, param_names, truths) do param_name, truth
        make_prediction_dataframe(param_name, samples, truth; model)
    end
    return score(df,
            transform_forecasts = transform_forecasts)
end
```

At the moment the `score_parameters` method used does

1. for each parameter
  a. Make prediction dataframe
  b. score this
2. `vcat` score dataframes

Which seems inefficient but does not Segfault.